### PR TITLE
yangcli: add ssh agent support

### DIFF
--- a/netconf/modules/yuma123/yangcli.yang
+++ b/netconf/modules/yuma123/yangcli.yang
@@ -52,6 +52,11 @@ module yangcli {
            input breaks in the script or command will be skipped.
          ";
 
+    revision 2018-04-21 {
+        description
+          "Added use-agent leaf to ssh configuration.";
+    }
+
     revision 2017-03-26 {
         description
           "Changed namespace in order to edit the original
@@ -507,6 +512,15 @@ module yangcli {
              or not done, then password authentication will
              be attempted.";
           default "$HOME/.ssh/id_rsa";
+        }
+
+        leaf use-agent {
+          description
+            "When true, attempt to hand off authentication
+             tasks to an SSH agent.  Requires the server to
+             support public key authentication.";
+          type boolean;
+          default false;
         }
 
         uses ncxapp:ProtocolsParm;

--- a/netconf/src/mgr/mgr.c
+++ b/netconf/src/mgr/mgr.c
@@ -341,6 +341,12 @@ void
         mscb->modules_state_val = NULL;
     }
 
+    if (mscb->agent) {
+        libssh2_agent_disconnect(mscb->agent);
+        libssh2_agent_free(mscb->agent);
+        mscb->agent = NULL;
+    }
+
     if (mscb->channel) {
         libssh2_channel_free(mscb->channel);
         mscb->channel = NULL;

--- a/netconf/src/mgr/mgr.h
+++ b/netconf/src/mgr/mgr.h
@@ -90,6 +90,7 @@ typedef struct mgr_scb_t_ {
     xmlChar         *target;
     LIBSSH2_SESSION *session;
     LIBSSH2_CHANNEL *channel;
+    LIBSSH2_AGENT   *agent;
     int              returncode;
 
     /* RPC request info */

--- a/netconf/src/mgr/mgr_ses.h
+++ b/netconf/src/mgr/mgr_ses.h
@@ -123,6 +123,7 @@ extern void
 *   password == user password
 *   pubkeyfile == filespec for client public key
 *   privkeyfile == filespec for client private key
+*   ssh_use_agent == TRUE if the agent to be used for authentication
 *   target == ASCII IP address or DNS hostname of target
 *   port == NETCONF port number to use, or 0 to use defaults
 *   transport == enum for the transport to use (SSH or TCP)
@@ -146,6 +147,7 @@ extern status_t
                          const xmlChar *password,
                          const char *pubkeyfile,
                          const char *privkeyfile,
+                         boolean ssh_use_agent,
                          const xmlChar *target,
                          uint16 port,
                          ses_transport_t transport,

--- a/netconf/src/yangcli/yangcli.h
+++ b/netconf/src/yangcli/yangcli.h
@@ -212,6 +212,7 @@ extern "C" {
 #define YANGCLI_TIMEOUT     (const xmlChar *)"timeout"
 #define YANGCLI_TIME_RPCS   (const xmlChar *)"time-rpcs"
 #define YANGCLI_TRANSPORT   (const xmlChar *)"transport"
+#define YANGCLI_USE_AGENT   (const xmlChar *)"use-agent"
 #define YANGCLI_USE_XMLHEADER (const xmlChar *)"use-xmlheader"
 #define YANGCLI_USER        (const xmlChar *)"user"
 #define YANGCLI_USERVARS_FILE  (const xmlChar *)"uservars-file"

--- a/netconf/src/yangcli/yangcli_cmd.c
+++ b/netconf/src/yangcli/yangcli_cmd.c
@@ -2051,6 +2051,7 @@ void
     uint16                  port;
     boolean                 startedsession, tcp, portbydefault;
     boolean                 tcp_direct_enable;
+    boolean                 ssh_use_agent;
 
     if (LOGDEBUG) {
         log_debug("\nConnect attempt with following parameters:");
@@ -2167,6 +2168,15 @@ void
             port = SES_DEF_TCP_PORT;
         }
     }
+
+    ssh_use_agent = FALSE;
+    val = val_find_child(server_cb->connect_valset,
+                         YANGCLI_MOD, YANGCLI_USE_AGENT);
+    if (val != NULL &&
+        val->res == NO_ERR &&
+        VAL_BOOL(val)) {
+        ssh_use_agent = TRUE;
+    }
         
     log_info("\nyangcli: Starting NETCONF session for %s on %s",
              username, 
@@ -2182,6 +2192,7 @@ void
                               password, 
                               publickey,
                               privatekey,
+                              ssh_use_agent,
                               server, 
                               port,
                               (tcp) ? ((tcp_direct_enable) ? SES_TRANSPORT_TCP_DIRECT : SES_TRANSPORT_TCP)


### PR DESCRIPTION
Allow a forwarded SSH agent connection to be used for authenticating
yangcli sessions.