### PR TITLE
add the perl XS modules source to the distribution tar file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -151,6 +151,9 @@ $(top_srcdir)/netconf/src/yangrpc/yangrpc.h
 
 EXTRA_DIST= \
 netconf/src/yangdiff \
+netconf/perl/yangcli \
+netconf/perl/yangrpc \
+netconf/perl/yuma \
 example-modules/ietf-interfaces \
 example-modules/ietf-system \
 rpm


### PR DESCRIPTION
Including these files will allow the perl modules to be built from an
RPM spec file external to the distribution and does not interfere with
building the yuma123 RPMs.