### PR TITLE
Initial commit

### DIFF
--- a/netconf/src/agt/agt.c
+++ b/netconf/src/agt/agt.c
@@ -1128,6 +1128,14 @@ status_t
         cfg_set_state(NCX_CFGID_STARTUP, CFG_ST_READY);
     }
 
+    /* Now that the SIL callbacks have been run for the COMMIT
+     * phase and the running configuration has been marked "ready",
+     * invoke the user commit-complete functions.
+     */
+    res = agt_commit_complete();
+    if (res != NO_ERR)
+        return res;
+
     /* data modules can be accessed now, and still added
      * and deleted dynamically as well
      *

--- a/netconf/test/netconfd/agt-commit-complete/session.py
+++ b/netconf/test/netconfd/agt-commit-complete/session.py
@@ -10,8 +10,6 @@ if(conn==None):
     sys.exit(1)
 
 
-result=yangcli(conn, "commit")
-assert(result.xpath('./ok'))
 yangcli(conn, "replace /system/hostname value='ok3'")
 yangcli(conn, "replace /system/location value='ok4'")
 result=yangcli(conn, "commit")


### PR DESCRIPTION
Finish running the user callbacks after loading the startup configuration.  This avoids having to initiate an empty commit to get the commit-complete callbacks to run for the first time.