### PR TITLE
validate union

### DIFF
--- a/netconf/src/agt/agt_util.c
+++ b/netconf/src/agt/agt_util.c
@@ -915,9 +915,21 @@ void
                                               (val_value_t *)error_path, 
                                               NCX_IFMT_XPATH1, 
                                               FALSE, &pathbuff);
+                /* Since we're generating the error-path, ignore
+                 * data validation failures resulting from formatting
+                 * the instance string.  These will mask the error
+                 * being reported here.
+                 */
                 if (res2 != NO_ERR) {
-                    log_error("\nError: Generate instance id failed (%s)",
-                              get_error_string(res2));
+                    if (pathbuff == NULL || res2 == ERR_INTERNAL_MEM) {
+                        log_error("\nError: Generate instance id failed (%s)",
+                                  get_error_string(res2));
+                        if (pathbuff)
+                            m__free(pathbuff);
+                    } else if (LOGDEBUG3) {
+                        log_debug3("\n%s using instance id in spite of error (%s)",
+                                   __func__, get_error_string(res2));
+                    }
                 }
                 break;
             case NCX_NT_OBJ:

--- a/netconf/src/ncx/json_wr.c
+++ b/netconf/src/ncx/json_wr.c
@@ -73,15 +73,15 @@ static status_t
     write_json_string_value (ses_cb_t *scb,
                              val_value_t *val)
 {
-    xmlChar *valstr = val_make_sprintf_string(val);
-    if (valstr) {
+    xmlChar *valstr = NULL;
+    status_t err = val_make_sprintf_string(val, &valstr);
+    if (err == NO_ERR) {
         ses_putchar(scb, '"');
         ses_putjstr(scb, valstr, -1);
         ses_putchar(scb, '"');
         m__free(valstr);
-        return NO_ERR;
     }
-    return ERR_INTERNAL_MEM;
+    return err;
 
 } /* write_json_string_value */
 

--- a/netconf/src/ncx/val.c
+++ b/netconf/src/ncx/val.c
@@ -8123,13 +8123,16 @@ status_t
 * INPUTS:
 *    val == value to print
 *
+* OUTPUTS:
+*    str == pointer to m__getMem() allocated buffer with string
+*    represetation of the 'val' value node.  This value is unchanged
+*    on error.
+*
 * RETURNS:
-*   malloced buffer with string represetation of the
-*     'val' value node
-*   NULL if some error
+*    status
 *********************************************************************/
-xmlChar *
-    val_make_sprintf_string (const val_value_t *val)
+status_t
+    val_make_sprintf_string (const val_value_t *val, xmlChar **str)
 {
     xmlChar   *buff;
     uint32     len;
@@ -8138,19 +8141,20 @@ xmlChar *
     len = 0;
     res = val_sprintf_simval_nc(NULL, val, &len);
     if (res != NO_ERR) {
-        return NULL;
+        return res;
     }
     buff = m__getMem(len+1);
     if (buff == NULL) {
-        return NULL;
+        return ERR_INTERNAL_MEM;
     }
     res = val_sprintf_simval_nc(buff, val, &len);
     if (res != NO_ERR) {
         m__free(buff);
-        return NULL;
+        return res;
     }
 
-    return buff;
+    *str = buff;
+    return NO_ERR;
 
 }  /* val_make_sprintf_string */
 

--- a/netconf/src/ncx/val.h
+++ b/netconf/src/ncx/val.h
@@ -2669,13 +2669,17 @@ extern status_t
 * INPUTS:
 *    val == value to print
 *
+* OUTPUTS:
+*    str == pointer to m__getMem() allocated buffer with string
+*    represetation of the 'val' value node.  This value is unchanged
+*    on error.
+*
 * RETURNS:
-*   malloced buffer with string represetation of the
-*      'val' value node
-*   NULL if some error
+*    status
 *********************************************************************/
-extern xmlChar *
-    val_make_sprintf_string (const val_value_t *val);
+status_t
+    val_make_sprintf_string (const val_value_t *val, xmlChar **str);
+
 
 
 /********************************************************************

--- a/netconf/src/ncx/val_get_leafref_targval.c
+++ b/netconf/src/ncx/val_get_leafref_targval.c
@@ -40,11 +40,11 @@ val_value_t* val_get_leafref_targval(val_value_t *leafref_val, val_value_t *root
         val = resnode->node.valptr;
         target_str = val_make_sprintf_string(val);
         if(0==strcmp(target_str,VAL_STRING(leafref_val))) {
-            free(target_str);
+            m__free(target_str);
             target_val = val;
             break;
         }
-        free(target_str);
+        m__free(target_str);
     }
     free(result);
     return target_val;

--- a/netconf/src/ncx/val_get_leafref_targval.c
+++ b/netconf/src/ncx/val_get_leafref_targval.c
@@ -35,11 +35,12 @@ val_value_t* val_get_leafref_targval(val_value_t *leafref_val, val_value_t *root
     for (resnode = (xpath_resnode_t *)dlq_firstEntry(&result->r.nodeQ);
          resnode != NULL;
          resnode = (xpath_resnode_t *)dlq_nextEntry(resnode)) {
-        char* target_str;
+        xmlChar* target_str;
         val_value_t* val;
         val = resnode->node.valptr;
-        target_str = val_make_sprintf_string(val);
-        if(0==strcmp(target_str,VAL_STRING(leafref_val))) {
+        res = val_make_sprintf_string(val, &target_str);
+        assert(res == NO_ERR);
+        if(0==xmlStrcmp(target_str,VAL_STRING(leafref_val))) {
             m__free(target_str);
             target_val = val;
             break;

--- a/netconf/src/ncx/val_util.c
+++ b/netconf/src/ncx/val_util.c
@@ -727,8 +727,9 @@ static status_t
     } else if (val->obj->objtype == OBJ_TYP_LEAF_LIST) {
         /* leaf-list e.g. /ex:system/ex:services/ex:ssh/ex:cipher[.='blowfish-cbc'] */
         int sprinted_cnt;
-        xmlChar *val_str;
-        val_str = val_make_sprintf_string(val);
+        xmlChar *val_str = NULL;
+
+        res = val_make_sprintf_string(val, &val_str);
         assert(val_str);
         sprinted_cnt=snprintf((char *)buff, buff?(*len-total):0, "[.='%s']", val_str);
         m__free(val_str);

--- a/netconf/src/ncx/val_util.c
+++ b/netconf/src/ncx/val_util.c
@@ -731,7 +731,7 @@ static status_t
         val_str = val_make_sprintf_string(val);
         assert(val_str);
         sprinted_cnt=snprintf((char *)buff, buff?(*len-total):0, "[.='%s']", val_str);
-        free(val_str);
+        m__free(val_str);
         if(buff) {
             buff+=sprinted_cnt;
         }

--- a/netconf/src/ncx/xml_wr.c
+++ b/netconf/src/ncx/xml_wr.c
@@ -648,10 +648,11 @@ static void write_binary_val( ses_cb_t *scb,
                               const val_value_t* out,
                               int32 indent )
 {
-    xmlChar* binStr = val_make_sprintf_string( out );
-    if ( !binStr )
+    xmlChar* binStr;
+    status_t res = val_make_sprintf_string( out, &binStr );
+    if ( res != NO_ERR )
     {
-        SET_ERROR(ERR_INTERNAL_MEM);
+        SET_ERROR(res);
         return;
     }
 

--- a/netconf/src/yangcli/yangcli_eval.c
+++ b/netconf/src/yangcli/yangcli_eval.c
@@ -324,10 +324,8 @@ status_t
              *   <data> contains multiple elements
              */
             if (typ_is_simple(resultval->btyp)) {
-                resultstr = val_make_sprintf_string(resultval);
-                if (resultstr == NULL) {
-                    res = ERR_INTERNAL_MEM;
-                } else {
+                res = val_make_sprintf_string(resultval, &resultstr);
+                if (res == NO_ERR) {
                     val_free_value(resultval);
                     resultval = NULL;
                 }
@@ -342,10 +340,8 @@ status_t
                         res = SET_ERROR(ERR_INTERNAL_VAL);
                     } else if (typ_is_simple(childval->btyp)) {
                         /* convert the simple val to a string */
-                        resultstr = val_make_sprintf_string(childval);
-                        if (resultstr == NULL) {
-                            res = ERR_INTERNAL_MEM;
-                        } else {
+                        res = val_make_sprintf_string(childval, &resultstr);
+                        if (res == NO_ERR) {
                             val_free_value(resultval);
                             resultval = NULL;
                         }

--- a/netconf/test/netconfd/Makefile.am
+++ b/netconf/test/netconfd/Makefile.am
@@ -2,6 +2,7 @@ TESTS=\
 test-perf \
 test-anyxml \
 test-val123-api \
+test-leaflist-union \
 test-netconf-1dot1 \
 test-yang-validation \
 test-copy-config \

--- a/netconf/test/netconfd/leaflist-union/leaflist-union-test.yang
+++ b/netconf/test/netconfd/leaflist-union/leaflist-union-test.yang
@@ -1,0 +1,24 @@
+module leaflist-union-test {
+
+        namespace "http://yuma123.org/ns/test-leaflist-union-test";
+        prefix "llut";
+	import ietf-inet-types { prefix inet; }
+        organization  "yuma123.org";
+        description
+          "Model used for regression test";
+
+        revision 2018-06-11 {
+                description
+                  "Initial revision";
+                reference
+                  "RFC ...";
+        }
+
+	container test {
+		leaf-list address {
+			type inet:ip-address;
+			description
+			 "An IP address";
+		}
+	}
+}

--- a/netconf/test/netconfd/leaflist-union/run.sh
+++ b/netconf/test/netconfd/leaflist-union/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+rm -rf tmp
+mkdir tmp
+if [ "$RUN_WITH_CONFD" != "" ] ; then
+  exit 0
+else
+  killall -KILL netconfd || true
+  rm -f /tmp/ncxserver.sock
+  /usr/sbin/netconfd --module=ietf-inet-types --module=leaflist-union-test --no-startup --validate-config-only --superuser=$USER
+  /usr/sbin/netconfd --module=ietf-inet-types --module=leaflist-union-test --no-startup --superuser=$USER 1>tmp/server.log 2>&1 &
+  SERVER_PID=$!
+fi
+
+sleep 3
+python session.litenc.py
+
+cat tmp/server.log
+sleep 1
+
+# it's ok for the grep command below to fail
+set +e
+grep -q 'get_instance_string.*Assertion' tmp/server.log && exit 1
+exit 0

--- a/netconf/test/netconfd/leaflist-union/session.litenc.py
+++ b/netconf/test/netconfd/leaflist-union/session.litenc.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+import time
+import sys, os
+sys.path.append("../../litenc")
+import litenc
+import litenc_lxml
+import lxml
+import argparse
+
+def main():
+	print("""
+#Description: Send invalid configuration.  Check later to see if
+# netconfd crashed.
+""")
+
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--server", help="server name e.g. 127.0.0.1 or server.com (127.0.0.1 if not specified)")
+	parser.add_argument("--user", help="username e.g. admin ($USER if not specified)")
+	parser.add_argument("--port", help="port e.g. 830 (830 if not specified)")
+	parser.add_argument("--password", help="password e.g. mypass123 (passwordless if not specified)")
+
+	args = parser.parse_args()
+
+	if(args.server==None or args.server==""):
+		server="127.0.0.1"
+	else:
+		server=args.server
+
+	if(args.port==None or args.port==""):
+		port=830
+	else:
+		port=int(args.port)
+
+	if(args.user==None or args.user==""):
+		user=os.getenv('USER')
+	else:
+		user=args.user
+
+	if(args.password==None or args.password==""):
+		password=None
+	else:
+		password=args.password
+
+
+	conn_raw = litenc.litenc()
+	ret = conn_raw.connect(server=server, port=port, user=user, password=password)
+	if ret != 0:
+		print "[FAILED] Connecting to server=%(server)s:" % {'server':server}
+		return(-1)
+	print "[OK] Connecting to server=%(server)s:" % {'server':server}
+	conn=litenc_lxml.litenc_lxml(conn_raw)
+	ret = conn_raw.send("""
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+ <capabilities>
+  <capability>urn:ietf:params:netconf:base:1.0</capability>
+ </capabilities>
+</hello>
+""")
+	if ret != 0:
+		print("[FAILED] Sending <hello>")
+		return(-1)
+
+	# receive <hello>
+	result=conn.receive()
+
+
+        print("# send invalid value for union element of leaf-list")
+
+	get_rpc = """
+<edit-config xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <target>
+    <candidate/>
+  </target>
+  <default-operation>merge</default-operation>
+  <test-option>set</test-option>
+  <config>
+    <test
+      xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"
+      nc:operation="create"
+      xmlns="http://yuma123.org/ns/test-leaflist-union-test">
+      <address>this should not work</address>
+    </test>
+  </config>
+</edit-config>
+"""
+	print("edit-config ...")
+	result = conn.rpc(get_rpc)
+	result=litenc_lxml.strip_namespaces(result)
+
+	print lxml.etree.tostring(result)
+
+        return(0)
+
+sys.exit(main())

--- a/netconf/test/netconfd/test-leaflist-union
+++ b/netconf/test/netconfd/test-leaflist-union
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+cd leaflist-union
+./run.sh


### PR DESCRIPTION
This fixes a case where a client could cause netconfd to abort by sending it data that fails a validation test.