### PR TITLE
fix null pointer error during netconfd shutdown

### DIFF
--- a/netconf/src/agt/agt.c
+++ b/netconf/src/agt/agt.c
@@ -1160,8 +1160,8 @@ void
         agt_acm_cleanup();
         agt_ncx_cleanup();
         agt_hello_cleanup();
-        agt_cli_cleanup();
         agt_nmda_cleanup();
+        agt_cli_cleanup();
         agt_yang_library_cleanup();
         agt_sys_cleanup();
         agt_state_cleanup();


### PR DESCRIPTION
agt_cleanup() calls a series of cleanup functions.  In the process,
agt_cli_cleanup() frees the pointer, cli_val, and agt_nmda_cleanup()
later tries to use it.  This results in the following message:

	Shutting down the netconfd server

	E0:
	   ../../../netconf/src/ncx/val.c:5836
	   Error 2: NULL pointer

	Session 1 closed

	*** Total Internal Errors: 1 ***

Swap the order in which these two functions are called.