### PR TITLE
do not leak private key passphrase to ssh server

### DIFF
--- a/netconf/doc/yuma_docs/yuma-yangcli-manual.txt
+++ b/netconf/doc/yuma_docs/yuma-yangcli-manual.txt
@@ -9059,6 +9059,38 @@ If both 'public-key' and 'private-key' files are present, the client will attemp
 |   yangcli –private-key=~/.ssh/mykey
 
 |}
+== --privkey-passphrase ==
+The '''--privkey-passphrase''' parameter specifies the passphrase used to unlock an encrypted client-side private key.
+
+<center>'''--privkey-passphrase parameter'''</center>
+
+
+
+{| class=wikitable border="1"
+|  Syntax
+|  string
+
+|-
+|  Default:
+|  none
+
+|-
+|  Min Allowed:
+|  0
+
+|-
+|  Max Allowed:
+|  1
+
+|-
+|  Supported by:
+|  yangcli
+
+|-
+|  Example:
+|   yangcli –privkey-passphrase='my-secret-passphrase'
+
+|}
 == --protocols ==
 The '''--protocols''' parameter specifies which protocol versions the program or session will attempt to use. Empty set is not allowed. 
 

--- a/netconf/modules/yuma123/yangcli.yang
+++ b/netconf/modules/yuma123/yangcli.yang
@@ -477,6 +477,13 @@ module yangcli {
           ncx:password;
         }
 
+        leaf privkey-passphrase {
+          description
+            "Passphrase to unlock the SSH private key.";
+          type string;
+          ncx:password;
+        }
+
         leaf ncport {
           description 
             "NETCONF port number to use.  If not present, then

--- a/netconf/src/mgr/mgr_ses.c
+++ b/netconf/src/mgr/mgr_ses.c
@@ -221,6 +221,7 @@ static status_t
                 const char *password,
                 const char *pubkeyfile,
                 const char *privkeyfile,
+                const char *privkeypass,
                 boolean ssh_use_agent)
                 
 {
@@ -393,7 +394,7 @@ agent_done:
                     (mscb->session, user, 
                      (const char *)expand_pubkey, 
                      (const char *)expand_privkey, 
-                     password);
+                     privkeypass ? privkeypass : "");
                 m__free(expand_pubkey);
                 m__free(expand_privkey);
 
@@ -841,6 +842,7 @@ status_t
                          const xmlChar *password,
                          const char *pubkeyfile,
                          const char *privkeyfile,
+                         const xmlChar *privkeypass,
                          boolean ssh_use_agent,
                          const xmlChar *target,
                          uint16 port,
@@ -963,6 +965,7 @@ status_t
                          (const char *)password,
                          pubkeyfile,
                          privkeyfile,
+                         (const char *)privkeypass,
                          ssh_use_agent);
     } else if (res == NO_ERR && transport == SES_TRANSPORT_TCP) {
         int flags = fcntl(scb->fd, F_GETFL, 0);

--- a/netconf/src/mgr/mgr_ses.h
+++ b/netconf/src/mgr/mgr_ses.h
@@ -123,6 +123,7 @@ extern void
 *   password == user password
 *   pubkeyfile == filespec for client public key
 *   privkeyfile == filespec for client private key
+*   privkeypass == passphrase to unlock private key
 *   ssh_use_agent == TRUE if the agent to be used for authentication
 *   target == ASCII IP address or DNS hostname of target
 *   port == NETCONF port number to use, or 0 to use defaults
@@ -147,6 +148,7 @@ extern status_t
                          const xmlChar *password,
                          const char *pubkeyfile,
                          const char *privkeyfile,
+                         const xmlChar *privkeypass,
                          boolean ssh_use_agent,
                          const xmlChar *target,
                          uint16 port,

--- a/netconf/src/yangcli/yangcli.h
+++ b/netconf/src/yangcli/yangcli.h
@@ -198,6 +198,7 @@ extern "C" {
 #define YANGCLI_PASSWORD    (const xmlChar *)"password"
 #define YANGCLI_PROTOCOLS   (const xmlChar *)"protocols"
 #define YANGCLI_PRIVATE_KEY (const xmlChar *)"private-key"
+#define YANGCLI_PRIVKEY_PASSPHRASE (const xmlChar *)"privkey-passphrase"
 #define YANGCLI_PUBLIC_KEY  (const xmlChar *)"public-key"
 #define YANGCLI_RESTART_OK  (const xmlChar *)"restart-ok"
 #define YANGCLI_RETRY_INTERVAL (const xmlChar *)"retry-interval"

--- a/netconf/src/yangcli/yangcli_cmd.c
+++ b/netconf/src/yangcli/yangcli_cmd.c
@@ -2043,6 +2043,7 @@ void
     create_session (server_cb_t *server_cb)
 {
     const xmlChar          *server, *username, *password;
+    const xmlChar          *privkeypass;
     const char             *publickey, *privatekey;
     modptr_t               *modptr;
     ncxmod_search_result_t *searchresult;
@@ -2141,6 +2142,13 @@ void
         privatekey = (const char *)VAL_STR(val);
     }
 
+    privkeypass = NULL;
+    val = val_find_child(server_cb->connect_valset,
+                         YANGCLI_MOD, YANGCLI_PRIVKEY_PASSPHRASE);
+    if (val && val->res == NO_ERR) {
+        privkeypass = (const xmlChar *)VAL_STR(val);
+    }
+
     tcp = FALSE;
     val = val_find_child(server_cb->connect_valset,
                          YANGCLI_MOD, YANGCLI_TRANSPORT);
@@ -2192,6 +2200,7 @@ void
                               password, 
                               publickey,
                               privatekey,
+                              privkeypass,
                               ssh_use_agent,
                               server, 
                               port,


### PR DESCRIPTION
Create a new parameter, separate from the remote user's password, to hold
the SSH private key passphrase.  If public key authentication fails,
yangcli will fall back to password authentication.  Since the password
parameter was used to hold the private key passphrase, the passphrase
is sent to the SSH server.