### PR TITLE
avoid confusion with /usr/include/grp.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ $(top_srcdir)/netconf/src/ncx/yinyang.h \
 $(top_srcdir)/netconf/src/ncx/ncx.h \
 $(top_srcdir)/netconf/src/ncx/bobhash.h \
 $(top_srcdir)/netconf/src/ncx/log.h \
-$(top_srcdir)/netconf/src/ncx/grp.h \
+$(top_srcdir)/netconf/src/ncx/ncx_grp.h \
 $(top_srcdir)/netconf/src/ncx/tstamp.h \
 $(top_srcdir)/netconf/src/ncx/xpath_yang.h \
 $(top_srcdir)/netconf/src/ncx/status.h \

--- a/netconf/src/ncx/ext.c
+++ b/netconf/src/ncx/ext.c
@@ -48,8 +48,8 @@ date         init     comment
 #include "ext.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_ncxconst

--- a/netconf/src/ncx/grp.c
+++ b/netconf/src/ncx/grp.c
@@ -44,8 +44,8 @@ date         init     comment
 #include "dlq.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_ncxconst

--- a/netconf/src/ncx/libncx.h
+++ b/netconf/src/ncx/libncx.h
@@ -120,8 +120,8 @@ extern "C" {
 #include "getcb.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_help

--- a/netconf/src/ncx/ncx.c
+++ b/netconf/src/ncx/ncx.c
@@ -57,7 +57,7 @@ date         init     comment
 #include "def_reg.h"
 #include "dlq.h"
 #include "ext.h"
-#include "grp.h"
+#include "ncx_grp.h"
 #include "log.h"
 #include "ncx.h"
 #include "ncx_appinfo.h"

--- a/netconf/src/ncx/ncx.h
+++ b/netconf/src/ncx/ncx.h
@@ -67,8 +67,8 @@ date	     init     comment
 #include "dlq.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_log

--- a/netconf/src/ncx/ncx_grp.h
+++ b/netconf/src/ncx/ncx_grp.h
@@ -8,10 +8,10 @@
  * specific language governing permissions and limitations
  * under the License.    
  */
-#ifndef _H_grp
-#define _H_grp
+#ifndef _H_ncx_grp
+#define _H_ncx_grp
 
-/*  FILE: grp.h
+/*  FILE: ncx_grp.h
 *********************************************************************
 *								    *
 *			 P U R P O S E				    *

--- a/netconf/src/ncx/obj.c
+++ b/netconf/src/ncx/obj.c
@@ -36,7 +36,7 @@ date         init     comment
 
 #include "procdefs.h"
 #include "dlq.h"
-#include "grp.h"
+#include "ncx_grp.h"
 #include "ncxconst.h"
 #include "ncx.h"
 #include "ncx_appinfo.h"

--- a/netconf/src/ncx/obj.h
+++ b/netconf/src/ncx/obj.h
@@ -36,7 +36,7 @@ date	     init     comment
 #include <libxml/xmlstring.h>
 #include <libxml/xmlregexp.h>
 
-#include "grp.h"
+#include "ncx_grp.h"
 #include "ncxconst.h"
 #include "ncxtypes.h"
 #include "status.h"

--- a/netconf/src/ncx/xpath.c
+++ b/netconf/src/ncx/xpath.c
@@ -35,7 +35,7 @@ date         init     comment
 
 #include "procdefs.h"
 #include "dlq.h"
-#include "grp.h"
+#include "ncx_grp.h"
 #include "ncxconst.h"
 #include "ncx.h"
 #include "ncx_num.h"

--- a/netconf/src/ncx/xpath1.c
+++ b/netconf/src/ncx/xpath1.c
@@ -38,7 +38,7 @@ date         init     comment
 #include  "procdefs.h"
 #include "def_reg.h"
 #include "dlq.h"
-#include "grp.h"
+#include "ncx_grp.h"
 #include "ncxconst.h"
 #include "ncx.h"
 #include "ncx_feature.h"

--- a/netconf/src/ncx/yang.c
+++ b/netconf/src/ncx/yang.c
@@ -52,8 +52,8 @@ date         init     comment
 #include  "ext.h"
 #endif
 
-#ifndef _H_grp
-#include  "grp.h"
+#ifndef _H_ncx_grp
+#include  "ncx_grp.h"
 #endif
 
 #ifndef _H_log

--- a/netconf/src/ncx/yang.h
+++ b/netconf/src/ncx/yang.h
@@ -43,8 +43,8 @@ date	     init     comment
 #include "ext.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_ncxtypes

--- a/netconf/src/ncx/yang_grp.h
+++ b/netconf/src/ncx/yang_grp.h
@@ -37,8 +37,8 @@ date	     init     comment
 #include "dlq.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_ncxtypes

--- a/netconf/src/ncx/yang_obj.c
+++ b/netconf/src/ncx/yang_obj.c
@@ -127,7 +127,7 @@ date         init     comment
 #include "procdefs.h"
 #include "def_reg.h"
 #include "dlq.h"
-#include "grp.h"
+#include "ncx_grp.h"
 #include "log.h"
 #include "ncxconst.h"
 #include "ncxtypes.h"

--- a/netconf/src/ncx/yang_obj.h
+++ b/netconf/src/ncx/yang_obj.h
@@ -132,8 +132,8 @@ date	     init     comment
 #include "dlq.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_ncxtypes

--- a/netconf/src/ncx/yang_typ.h
+++ b/netconf/src/ncx/yang_typ.h
@@ -37,8 +37,8 @@ date	     init     comment
 #include "dlq.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_ncxtypes

--- a/netconf/src/ydump/cyang.c
+++ b/netconf/src/ydump/cyang.c
@@ -52,8 +52,8 @@ date         init     comment
 #include "ext.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_ncx

--- a/netconf/src/ydump/html.c
+++ b/netconf/src/ydump/html.c
@@ -47,8 +47,8 @@ date         init     comment
 #include "ext.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_html

--- a/netconf/src/ydump/sql.c
+++ b/netconf/src/ydump/sql.c
@@ -47,8 +47,8 @@ date         init     comment
 #include "ext.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_ncx

--- a/netconf/src/ydump/tg2.c
+++ b/netconf/src/ydump/tg2.c
@@ -122,8 +122,8 @@ date         init     comment
 #include "ext.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_ncx

--- a/netconf/src/ydump/yangtree.c
+++ b/netconf/src/ydump/yangtree.c
@@ -30,7 +30,7 @@
 #include "c_util.h"
 #include "dlq.h"
 #include "ext.h"
-#include "grp.h"
+#include "ncx_grp.h"
 #include "ncx.h"
 #include "ncxconst.h"
 #include "ncxmod.h"

--- a/netconf/src/ydump/yangyin.c
+++ b/netconf/src/ydump/yangyin.c
@@ -47,8 +47,8 @@ date         init     comment
 #include "ext.h"
 #endif
 
-#ifndef _H_grp
-#include "grp.h"
+#ifndef _H_ncx_grp
+#include "ncx_grp.h"
 #endif
 
 #ifndef _H_ncx


### PR DESCRIPTION
Rename ncx/grp.h to ncx/ncx_grp.h for programs that include the system
grp.h header.