### PR TITLE
yangrpc: do not free literal strings

### DIFF
--- a/netconf/src/yangrpc/yangrpc.c
+++ b/netconf/src/yangrpc/yangrpc.c
@@ -671,7 +671,9 @@ status_t yangrpc_connect(const char * const server, uint16_t port,
 
     /* Get any command line and conf file parameters */
     res = process_cli_input(server_cb, argc, argv);
-    for(i=0;i<argc;i++) {
+
+    /* Skip argv[0] - it was not allocated with malloc */
+    for(i=1;i<argc;i++) {
         free(argv[i]);
     }
     if (res != NO_ERR) {


### PR DESCRIPTION
In yangrpc_connect(), all of the strings stored in the argv[] array are
malloc'ed except for argv[0].

Fixes: 430bac2f8e0d ("Refactored some avoidable static variables and
goto return logic")