### PR TITLE
netconfd: do not use session control block after free

### DIFF
--- a/netconf/src/agt/agt_ncxserver.c
+++ b/netconf/src/agt/agt_ncxserver.c
@@ -478,6 +478,7 @@ ses_accept_defered_input:
                                 agt_ses_kill_session(scb,
                                                      scb->sid,
                                                      SES_TR_DROPPED);
+                                scb = NULL;
                             }
                         }
                     }
@@ -491,6 +492,7 @@ ses_accept_defered_input:
             while (!done2) {
                 if (!agt_ses_process_first_ready()) {
                     done2 = TRUE;
+                    scb = NULL;
                 } else if (agt_shutdown_requested()) {
                     done = done2 = TRUE;
                 } else {


### PR DESCRIPTION
Set the "scb" pointer to NULL if the session was closed.  This avoids
problems like:

Session 1 closed
==9244== Invalid read of size 4
==9244==    at 0x4E5A507: agt_ncxserver_run (agt_ncxserver.c:500)
==9244==    by 0x109449: netconfd_run (netconfd.c:281)
==9244==    by 0x1095FA: main (netconfd.c:361)
==9244==  Address 0xc16d030 is 352 bytes inside a block of size 448
free'd
==9244==    at 0x4C30D3B: free (in
/usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9244==    by 0x50E7FFE: ses_free_scb (ses.c:1084)
==9244==    by 0x4E65990: agt_ses_free_session (agt_ses.c:721)
==9244==    by 0x4E65B6D: agt_ses_kill_session (agt_ses.c:848)
==9244==    by 0x4E5A458: agt_ncxserver_run (agt_ncxserver.c:478)
==9244==    by 0x109449: netconfd_run (netconfd.c:281)
==9244==    by 0x1095FA: main (netconfd.c:361)
==9244==  Block was alloc'd at
==9244==    at 0x4C2FB0F: malloc (in
/usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9244==    by 0x50E7B25: ses_new_scb (ses.c:945)
==9244==    by 0x4E65621: agt_ses_new_session (agt_ses.c:598)
==9244==    by 0x4E5A263: agt_ncxserver_run (agt_ncxserver.c:428)
==9244==    by 0x109449: netconfd_run (netconfd.c:281)
==9244==    by 0x1095FA: main (netconfd.c:361)
==9244==