### PR TITLE
Fixed segmentation fault when accessing null pointer obj.

### DIFF
--- a/netconf/src/ncx/obj.c
+++ b/netconf/src/ncx/obj.c
@@ -2313,6 +2313,9 @@ static obj_template_t* search_choice( obj_template_t* obj,
  */
 static boolean  obj_is_choice_or_case( obj_template_t* obj )
 {
+    if (!obj)
+        return false;
+    
     return ( obj->objtype == OBJ_TYP_CHOICE || obj->objtype == OBJ_TYP_CASE );
 }
 


### PR DESCRIPTION
Updating a configuration from an XML file as follows using yangcli caused a segmentation fault for some (not all) XML files:

$ merge /interfaces/interface[name='sw0p2']/gate-parameters --value=@gate-parameters.xml 

gdb showed an access to a NULL pointer: obj is NULL in function obj_is_choice_or_case( obj_template_t* obj )

Fixed by testing for obj being NULL before accessing it.
 