### PR TITLE
Clarifies function comment blocks re: defpath

### DIFF
--- a/netconf/src/agt/agt_cb.c
+++ b/netconf/src/agt/agt_cb.c
@@ -525,8 +525,10 @@ void
 * INPUTS:
 *   modname == module that defines the target object for
 *              these callback functions 
-*   defpath == Xpath with default (or no) prefixes
-*              defining the object that will get the callbacks
+*   defpath == Xpath defining the object that will get the callbacks.
+*              If no prefix is specified, try the first prefix that has
+*              a matching top-level object.  If child nodes are not found,
+*              return ERR_NCX_DEFSEG_NOT_FOUND.
 *   version == exact module revision date expected
 *              if condition not met then an error will
 *              be logged  (TBD: force unload of module!)

--- a/netconf/src/ncx/ncx.c
+++ b/netconf/src/ncx/ncx.c
@@ -1940,9 +1940,11 @@ void
 /**
  * \fn ncx_find_any_object
  * \brief Check if an obj_template_t in in any module that
- * matches the object name string
+ * matches the object name string.
+ * Note that if many modules have an object of the same name, this
+ * function will return only the first such object found. 
  * \param objname object name to match
- * \return pointer to struct if present, NULL otherwise
+ * \return pointer to first matching struct if present, NULL otherwise
  */
 obj_template_t *
     ncx_find_any_object (const xmlChar *objname)

--- a/netconf/src/ncx/xpath.c
+++ b/netconf/src/ncx/xpath.c
@@ -713,7 +713,15 @@ static status_t
 * 
 * Follow the absolute-path expression
 * and return the obj_template_t that it indicates
-* A missing prefix means check any namespace for the symbol
+* A missing prefix means check any namespace for the symbol and return
+* the first hit
+*
+* Note of caution: if top-level objects in different XML namespaces 
+* share the same name, e.g. "/system", only the first such object will
+* be searched for child nodes.  If a child node is not found because
+* the wrong object/wrong namespace was searched, the function will return
+* ERR_NCX_DEFSEG_NOT_FOUND.  In this case, a fully-qualified XPath with 
+* namespace should be used.
 *
 * !!! Internal version !!!
 * !!! Error messages are not printed by this function!!
@@ -785,7 +793,9 @@ static status_t
         /* get the first object template */
         curobj = obj_find_template_top(mod, ncx_get_modname(mod), name);
     } else {
-        /* no prefix given, check all top-level objects */
+        /* no prefix given, check all top-level objects and return
+        *  the first one found.  
+        */
         curobj = ncx_find_any_object(name);
     }
 


### PR DESCRIPTION
Relates to https://github.com/vlvassilev/yuma123/issues/140

This PR clarifies relevant functions comment blocks to more clearly reflect the behavior discussed in the issue above. This does not resolve the issue but changes 3 comment blocks to better document the namespace search behavior and allow SIL developers to more easily identify the cause of `ERR_NCX_DEFSEG_NOT_FOUND`.